### PR TITLE
Use v1beta2 Flux Kustomization API

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,7 +479,7 @@ EOF
 ```yaml
 cat > ./clusters/production/apps.yaml << EOF
 ---
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta1
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
 kind: Kustomization
 metadata:
   name: apps
@@ -493,14 +493,14 @@ spec:
     name: flux-system
   path: ./apps/production
   prune: true
-  validation: client
+  wait: true
 EOF
 ```
 
 ```yaml
 cat > ./clusters/production/infrastructure.yaml << EOF
 ---
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta1
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
 kind: Kustomization
 metadata:
   name: infrastructure
@@ -512,7 +512,7 @@ spec:
     name: flux-system
   path: ./infrastructure
   prune: true
-  validation: client
+  wait: true
 EOF
 ```
 
@@ -521,7 +521,7 @@ EOF
 ```yaml
 cat > ./clusters/staging/apps.yaml << EOF
 ---
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta1
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
 kind: Kustomization
 metadata:
   name: apps
@@ -535,13 +535,13 @@ spec:
     name: flux-system
   path: ./apps/staging
   prune: true
-  validation: client
+  wait: true
 EOF
 ```
 
 ```yaml
 cat > ./clusters/staging/infrastructure.yaml << EOF
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta1
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
 kind: Kustomization
 metadata:
   name: infrastructure
@@ -553,7 +553,7 @@ spec:
     name: flux-system
   path: ./infrastructure
   prune: true
-  validation: client
+  wait: true
 EOF
 ```
 

--- a/clusters/production/apps.yaml
+++ b/clusters/production/apps.yaml
@@ -1,6 +1,6 @@
 ---
 
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta1
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
 kind: Kustomization
 metadata:
   name: apps
@@ -14,4 +14,4 @@ spec:
     name: flux-system
   path: ./apps/production
   prune: true
-  validation: client
+  wait: true

--- a/clusters/production/infrastructure.yaml
+++ b/clusters/production/infrastructure.yaml
@@ -1,6 +1,6 @@
 ---
 
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta1
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
 kind: Kustomization
 metadata:
   name: infrastructure
@@ -12,4 +12,4 @@ spec:
     name: flux-system
   path: ./infrastructure
   prune: true
-  validation: client
+  wait: true

--- a/clusters/staging/apps.yaml
+++ b/clusters/staging/apps.yaml
@@ -1,6 +1,6 @@
 ---
 
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta1
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
 kind: Kustomization
 metadata:
   name: apps
@@ -14,4 +14,4 @@ spec:
     name: flux-system
   path: ./apps/staging
   prune: true
-  validation: client
+  wait: true

--- a/clusters/staging/infrastructure.yaml
+++ b/clusters/staging/infrastructure.yaml
@@ -1,6 +1,6 @@
 ---
 
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta1
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
 kind: Kustomization
 metadata:
   name: infrastructure
@@ -12,4 +12,4 @@ spec:
     name: flux-system
   path: ./infrastructure
   prune: true
-  validation: client
+  wait: true


### PR DESCRIPTION
This is another recent update: @jakubhajek I mentioned this in one of our dry-run sessions.

In Flux 0.18, the `kustomize.toolkit.fluxcd.io` API was upgraded from `v1beta1` to `v1beta2`. The `spec.wait` field was added and `spec.validation` was made ineffective, among several other changes.

https://github.com/fluxcd/kustomize-controller/pull/426

Setting `validation: client` or `validation: server` both have no effect as now Flux uses Server Side Apply which is always validating.

The key `validation` is still present in v1beta2 as it provides for backwards compatibility, but its value will have no effect, and the key itself will be removed in a later API upgrade, most likely some time around when Flux's "v2" release marks the APIs "finished" and likely to coincide with an announcement for General Availability.

You can leave the `validation` flag in place but, please be prepared to explain for users that it does not do anything in the most recent versions of Flux, that validation is now to be taken for granted or as given, and that it can no longer be disabled.